### PR TITLE
[WIP] Support Cucumber 2.0

### DIFF
--- a/lib/pretty_face/formatter/html.rb
+++ b/lib/pretty_face/formatter/html.rb
@@ -107,7 +107,7 @@ module PrettyFace
           @report.current_scenario.populate(example_row)
           build_scenario_outline_steps(example_row)
         end
-        populate_cells(example_row) if example_row.instance_of? Cucumber::Ast::Table::Cells
+        populate_cells(example_row) if example_row.instance_of? Cucumber::Core::Ast::DataTable
       end
 
       def before_step(step)
@@ -243,12 +243,12 @@ module PrettyFace
       end
 
       def scenario_outline?(feature_element)
-        feature_element.is_a? Cucumber::Ast::ScenarioOutline
+        feature_element.is_a? Cucumber::Core::Ast::ScenarioOutline
       end
 
       def info_row?(example_row)
         return example_row.scenario_outline.nil? if example_row.respond_to? :scenario_outline
-        return true if example_row.instance_of? Cucumber::Ast::Table::Cells
+        return true if example_row.instance_of? Cucumber::Core::Ast::DataTable
         false
       end
 

--- a/lib/pretty_face/formatter/html.rb
+++ b/lib/pretty_face/formatter/html.rb
@@ -2,9 +2,9 @@ require 'action_view'
 require 'fileutils'
 require 'cucumber/formatter/io'
 require 'cucumber/formatter/duration'
-require 'cucumber/ast/scenario'
-require 'cucumber/ast/table'
-require 'cucumber/ast/outline_table'
+require 'cucumber/core/ast/scenario'
+require 'cucumber/core/ast/data_table'
+require 'cucumber/core/ast/scenario_outline'
 require File.join(File.dirname(__FILE__), 'view_helper')
 require File.join(File.dirname(__FILE__), 'report')
 

--- a/lib/pretty_face/formatter/report.rb
+++ b/lib/pretty_face/formatter/report.rb
@@ -174,10 +174,10 @@ module PrettyFace
 
       def populate(scenario)
         @duration = Time.now - @start
-        if scenario.instance_of? Cucumber::Ast::Scenario
+        if scenario.instance_of? Cucumber::Core::Ast::Scenario
           @name = scenario.name
           @file_colon_line = scenario.file_colon_line
-        elsif scenario.instance_of? Cucumber::Ast::OutlineTable::ExampleRow
+        elsif scenario.instance_of? Cucumber::Core::Ast::ExamplesTable::Row
           @name = scenario.scenario_outline.name
           @file_colon_line = scenario.backtrace_line
         end
@@ -195,7 +195,7 @@ module PrettyFace
       def initialize(step)
         @name = step.name
         @file_colon_line = step.file_colon_line
-        unless step.instance_of? Cucumber::Ast::Background
+        unless step.instance_of? Cucumber::Core::Ast::Background
           if step.respond_to? :actual_keyword
             @keyword = step.actual_keyword
           else

--- a/lib/pretty_face/formatter/report.rb
+++ b/lib/pretty_face/formatter/report.rb
@@ -89,7 +89,7 @@ module PrettyFace
         @scenarios = []
         @background = []
         @start_time = Time.now
-        @description = feature.description
+        @description = feature.send(:description)
         @parent_filename = parent_filename
       end
 

--- a/lib/pretty_face/formatter/view_helper.rb
+++ b/lib/pretty_face/formatter/view_helper.rb
@@ -1,4 +1,4 @@
-require 'cucumber/ast/scenario_outline'
+require 'cucumber/core/ast/scenario_outline'
 
 module PrettyFace
   module Formatter

--- a/lib/pretty_face/formatter/view_helper.rb
+++ b/lib/pretty_face/formatter/view_helper.rb
@@ -49,6 +49,7 @@ module PrettyFace
       private
 
       def get_average_from_float_array(arr)
+        return 0 if arr.size == 0
         arr.reduce(:+).to_f / arr.size
       end
 

--- a/spec/lib/html_formatter_spec.rb
+++ b/spec/lib/html_formatter_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'cucumber/ast/step'
+require 'cucumber/core/ast/step'
 
 describe PrettyFace::Formatter::Html do
   let(:step_mother) { double('step_mother') }


### PR DESCRIPTION
In order to get the specs to run against Cucumber 2.0, this change requires files from the new cucumber-core gem.

_Next steps: to see whether the formatter works as intended. This change makes the specs run green._

  - see #39 

- [x] pass Spec specs
- [ ] pass Cucumber specs
- [ ] fully use Cucumber 2.0 API
- [ ] be able to create an HTML report on a simple Feature file (is there one for general testing use?)